### PR TITLE
erase ip detail on backend

### DIFF
--- a/api.js
+++ b/api.js
@@ -9,7 +9,19 @@ var a = [];
 
 const postserver = http.createServer((req, res) => {
   var q = url.parse(req.url, true).query;
-  q.ip = req.headers["x-real-ip"];
+  var ip = req.headers["x-real-ip"];
+  if (ip) {
+    ip = ip.split(".");
+    ip[0] = "**";
+    if (ip.length > 3) {
+      ip[3] = "**";
+    }
+    ip = ip.join(".");
+  }
+  else {
+    ip = "";
+  }
+  q.ip = ip;
   if (q.title || q.sid) {
     a.push(q);
   }


### PR DESCRIPTION
Storage full ip and sent it back to front-end request is unsafe as it's easy to get data before erase.

Also an empty ip field will cause front-end live score function crash, so add an empty string as default ip field if there is no `"x-real-ip"`,